### PR TITLE
Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.11.8
-  - 2.12.1
+  - 2.12.13
+  - 2.13.4
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ Uses Snappy's [framing format][snappy-framing].
 ## Getting started
 In your `build.sbt`:
 ```scala
-libraryDependencies += "me.maciejb.snappyflows" %% "snappy-flows" % "0.2.0"
+libraryDependencies += "me.maciejb.snappyflows" %% "snappy-flows" % "0.3.0"
 ```
-Snappy flows are available for both Scala 2.11 and 2.12.
-We use a recent Akka 2.4 branch version (2.4.14 as of snappy-flows 0.2.0). 
+Snappy flows are available for Scala 2.11, 2.12 and 2.13.
+We use a recent Akka 2.6 branch version (2.6.10 as of snappy-flows 0.3.0). 
 
 Previous releases:
 
 | Snappy flows     | Akka                 | Scala |
 |------------------|----------------------|--------
+| `0.2.0 - 0.2.1`  | Akka >2.4.2          | 2.11  |
 | `0.1.3 - 0.1.5`  | Akka >2.4.2          | 2.11  |
 | `  0.1.2      `  | Akka 2.4.2-RC3       | 2.11  |
 | `   0.1.1     `  | Akka Streams 2.0     | 2.11  |

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 1.3.13

--- a/project/build.scala
+++ b/project/build.scala
@@ -5,13 +5,13 @@ import sbt._
 import sbtrelease.ReleasePlugin.autoImport._
 
 object Versions {
-  val akka = "2.4.14"
+  val akka = "2.6.10"
 }
 
 //noinspection TypeAnnotation
 object Dependencies {
   val scalaTest =
-    "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+    "org.scalatest" %% "scalatest" % "3.2.3" % "test"
 
   val akka = Seq(
     "com.typesafe.akka" %% "akka-actor" % Versions.akka,
@@ -19,13 +19,13 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-stream" % Versions.akka
   )
 
-  val snappy = "org.xerial.snappy" % "snappy-java" % "1.1.2.6"
+  val snappy = "org.xerial.snappy" % "snappy-java" % "1.1.8.2"
 }
 
 object Settings {
   val common = Seq(
-    scalaVersion := "2.12.1",
-    crossScalaVersions := Seq(scalaVersion.value, "2.11.8"),
+    scalaVersion := "2.13.4",
+    crossScalaVersions := Seq(scalaVersion.value, "2.12.13"),
     organization := "me.maciejb.snappyflows",
     description := "Snappy compression Akka Streams flows",
     homepage := Some(url("https://github.com/maciej/snappy-flows")),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 logLevel := Level.Warn
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.2")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")

--- a/src/test/scala/me/maciejb/snappyflows/ManualTest.scala
+++ b/src/test/scala/me/maciejb/snappyflows/ManualTest.scala
@@ -1,8 +1,7 @@
 package me.maciejb.snappyflows
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{StreamConverters, Keep, Sink, Source}
+import akka.stream.scaladsl.{Keep, Sink, StreamConverters}
 import akka.util.ByteString
 
 import scala.concurrent.Await
@@ -10,7 +9,6 @@ import scala.concurrent.duration._
 
 object ManualTest extends App {
   implicit val system = ActorSystem()
-  implicit val mat = ActorMaterializer()
 
   val source = StreamConverters.
     fromInputStream(() => getClass.getClassLoader.getResourceAsStream("framing_format.txt.sz"))

--- a/src/test/scala/me/maciejb/snappyflows/RoundTripTest.scala
+++ b/src/test/scala/me/maciejb/snappyflows/RoundTripTest.scala
@@ -2,19 +2,19 @@ package me.maciejb.snappyflows
 
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Keep, Source, Sink}
+import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.testkit.{TestKit, TestKitBase}
 import akka.util.ByteString
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.{BeforeAndAfterAll, Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class RoundTripTest extends FlatSpec with Matchers with TestKitBase with BeforeAndAfterAll
+class RoundTripTest extends AnyFlatSpec with Matchers with TestKitBase with BeforeAndAfterAll
   with ScalaFutures with IntegrationPatience {
 
   override implicit lazy val system: ActorSystem = ActorSystem("RoundTripTest")
-  implicit lazy val mat = ActorMaterializer()
 
   import scala.concurrent.ExecutionContext.Implicits._
 

--- a/src/test/scala/me/maciejb/snappyflows/Snzip.scala
+++ b/src/test/scala/me/maciejb/snappyflows/Snzip.scala
@@ -1,11 +1,9 @@
 package me.maciejb.snappyflows
 
-import java.io.File
-
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{FileIO, Keep}
 
+import java.nio.file.Paths
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -13,12 +11,11 @@ import scala.concurrent.duration._
 object Snzip extends App {
 
   implicit val system = ActorSystem()
-  implicit val mat = ActorMaterializer()
   implicit val ec = concurrent.ExecutionContext.Implicits.global
 
-  val source = FileIO.fromFile(new File(args(0)), chunkSize = 65536)
+  val source = FileIO.fromPath(Paths.get(args(0)), chunkSize = 65536)
 
-  val sink = FileIO.toFile(new File(args(0) + ".sz"))
+  val sink = FileIO.toPath(Paths.get(args(0) + ".sz"))
 
   Await.ready(
     source.via(SnappyFlows.compressAsync(4)).log("compress").toMat(sink)(Keep.right).run()

--- a/src/test/scala/me/maciejb/snappyflows/impl/ChunkingTest.scala
+++ b/src/test/scala/me/maciejb/snappyflows/impl/ChunkingTest.scala
@@ -1,27 +1,26 @@
 package me.maciejb.snappyflows.impl
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.testkit.TestKit
 import akka.util.ByteString
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class ChunkingTest extends FlatSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class ChunkingTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 
   implicit lazy val system: ActorSystem = ActorSystem()
-  implicit lazy val mat: ActorMaterializer = ActorMaterializer()
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(scaled(500.millis), scaled(15.millis))
 
-  def byteStringSeq(strings: String*) = strings.map(ByteString.fromString).to[immutable.Seq]
+  def byteStringSeq(strings: String*) = strings.map(ByteString.fromString).toList
 
-  def chunk(size: Int, elems: immutable.Seq[ByteString]): Future[immutable.Seq[ByteString]] = {
+  def chunk(size: Int, elems: List[ByteString]): Future[Seq[ByteString]] = {
     Source(elems)
       .via(Chunking.fixedSize(size))
       .grouped(1024)


### PR DESCRIPTION
Key notes:
- update akka to 2.6
- cross-compile to Scala 2.12 and 2.13; end of support Scala 2.11
- set version to 0.3.0