### PR TITLE
Convert to pekko 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Maven Central][maven-central-badge]][maven-central-link]
 [![Build Status][travis-ci-badge]][travis-ci-link]
 
-Snappy compression and decompression [Akka Steams][akka-streams] `Flow`s.
+Snappy compression and decompression [Pekko Steams][pekko-streams] `Flow`s.
 
 Uses Snappy's [framing format][snappy-framing].
 
@@ -12,7 +12,7 @@ In your `build.sbt`:
 libraryDependencies += "me.maciejb.snappyflows" %% "snappy-flows" % "0.3.0"
 ```
 Snappy flows are available for Scala 2.11, 2.12 and 2.13.
-We use a recent Akka 2.6 branch version (2.6.10 as of snappy-flows 0.3.0). 
+We use a recent Pekko 1.0.1 branch version
 
 Previous releases:
 
@@ -55,15 +55,15 @@ For details refer to [benchmarks/README.md](benchmarks/README.md).
 ## Resources
 * [Reference Snappy implementation][google-snappy]
 * [Snappy for Java][snappy-java]
-* [Akka Streams documentation][akka-streams]
-* [Akka project][akka]
+* [Pekko Streams documentation][pekko-streams]
+* [Pekko project][pekko]
 * [Snappy flows at bintray][bintray-snappy-flows]
 
-[akka-streams]: http://doc.akka.io/docs/akka-stream-and-http-experimental/snapshot/scala.html
+[pekko-streams]: https://pekko.apache.org/docs/pekko/current/stream/stream-dynamic.html
 [snappy-framing]: https://github.com/google/snappy/blob/master/framing_format.txt
 [google-snappy]: https://github.com/google/snappy
 [snappy-java]: https://github.com/xerial/snappy-java
-[akka]: http://akka.io
+[pekko]: http://pekko.apache.org
 [maven-central-badge]: https://maven-badges.herokuapp.com/maven-central/me.maciejb.snappyflows/snappy-flows_2.11/badge.svg
 [maven-central-link]: https://maven-badges.herokuapp.com/maven-central/me.maciejb.snappyflows/snappy-flows_2.11
 [travis-ci-badge]: https://travis-ci.org/maciej/snappy-flows.svg

--- a/benchmarks/src/main/scala/me/maciejb/snappyflows/benchmarks/ChunkingBenchmark.scala
+++ b/benchmarks/src/main/scala/me/maciejb/snappyflows/benchmarks/ChunkingBenchmark.scala
@@ -1,9 +1,9 @@
 package me.maciejb.snappyflows.benchmarks
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Keep, Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.ActorMaterializer
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+import org.apache.pekko.util.ByteString
 import me.maciejb.snappyflows.SnappyFlows
 import me.maciejb.snappyflows.benchmarks.data.EColi
 import me.maciejb.snappyflows.impl.Chunking

--- a/benchmarks/src/main/scala/me/maciejb/snappyflows/benchmarks/CompressApp.scala
+++ b/benchmarks/src/main/scala/me/maciejb/snappyflows/benchmarks/CompressApp.scala
@@ -1,9 +1,9 @@
 package me.maciejb.snappyflows.benchmarks
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Keep, Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.ActorMaterializer
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+import org.apache.pekko.util.ByteString
 import me.maciejb.snappyflows.SnappyFlows
 import me.maciejb.snappyflows.benchmarks.data.EColi
 

--- a/benchmarks/src/main/scala/me/maciejb/snappyflows/benchmarks/CompressionBenchmark.scala
+++ b/benchmarks/src/main/scala/me/maciejb/snappyflows/benchmarks/CompressionBenchmark.scala
@@ -1,9 +1,9 @@
 package me.maciejb.snappyflows.benchmarks
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Keep, Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.ActorMaterializer
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+import org.apache.pekko.util.ByteString
 import me.maciejb.snappyflows.SnappyFlows
 import me.maciejb.snappyflows.benchmarks.data.EColi
 import me.maciejb.snappyflows.impl.Chunking

--- a/benchmarks/src/main/scala/me/maciejb/snappyflows/benchmarks/DecompressionBenchmark.scala
+++ b/benchmarks/src/main/scala/me/maciejb/snappyflows/benchmarks/DecompressionBenchmark.scala
@@ -2,10 +2,10 @@ package me.maciejb.snappyflows.benchmarks
 
 import java.io.ByteArrayInputStream
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Keep, Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.ActorMaterializer
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+import org.apache.pekko.util.ByteString
 import me.maciejb.snappyflows.SnappyFlows
 import me.maciejb.snappyflows.benchmarks.data.{EColiCompressed, EColi}
 import org.openjdk.jmh.annotations.{Scope, State, Benchmark, TearDown}

--- a/benchmarks/src/main/scala/me/maciejb/snappyflows/benchmarks/data/EColi.scala
+++ b/benchmarks/src/main/scala/me/maciejb/snappyflows/benchmarks/data/EColi.scala
@@ -2,10 +2,10 @@ package me.maciejb.snappyflows.benchmarks.data
 
 import java.nio.file.{Files, Path, Paths}
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Keep, Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.ActorMaterializer
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+import org.apache.pekko.util.ByteString
 import me.maciejb.snappyflows.SnappyFlows
 
 import scala.concurrent.Await

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,14 @@
 import _root_.pl.project13.scala.sbt.JmhPlugin
 import sbt.Keys._
 
+//resolvers += "apache" at "https://repository.apache.org/content/repositories/snapshots/"
+
 lazy val snappyFlows = project.in(file("."))
   .settings(name := "snappy-flows")
   .settings(Settings.common ++  Settings.release)
   .settings {
     import Dependencies._
-    libraryDependencies ++= akka ++ Seq(snappy, scalaTest)
+    libraryDependencies ++= pekko ++ Seq(snappy, scalaTest)
   }
   .enablePlugins(ReleasePlugin)
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -5,7 +5,7 @@ import sbt._
 import sbtrelease.ReleasePlugin.autoImport._
 
 object Versions {
-  val akka = "2.6.10"
+  val pekko = "1.0.1"
 }
 
 //noinspection TypeAnnotation
@@ -13,10 +13,10 @@ object Dependencies {
   val scalaTest =
     "org.scalatest" %% "scalatest" % "3.2.3" % "test"
 
-  val akka = Seq(
-    "com.typesafe.akka" %% "akka-actor" % Versions.akka,
-    "com.typesafe.akka" %% "akka-testkit" % Versions.akka % "test",
-    "com.typesafe.akka" %% "akka-stream" % Versions.akka
+  val pekko = Seq(
+    "org.apache.pekko" %% "pekko-actor" % Versions.pekko,
+    "org.apache.pekko" %% "pekko-testkit" % Versions.pekko % "test",
+    "org.apache.pekko" %% "pekko-stream" % Versions.pekko
   )
 
   val snappy = "org.xerial.snappy" % "snappy-java" % "1.1.8.2"

--- a/src/main/scala/me/maciejb/snappyflows/SnappyException.scala
+++ b/src/main/scala/me/maciejb/snappyflows/SnappyException.scala
@@ -1,6 +1,6 @@
 package me.maciejb.snappyflows
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 
 
 class SnappyException(desc: String, causeOpt: Option[Exception] = None)

--- a/src/main/scala/me/maciejb/snappyflows/SnappyFlows.scala
+++ b/src/main/scala/me/maciejb/snappyflows/SnappyFlows.scala
@@ -1,10 +1,10 @@
 package me.maciejb.snappyflows
 
 
-import akka.NotUsed
-import akka.stream.FlowShape
-import akka.stream.scaladsl._
-import akka.util.ByteString
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.FlowShape
+import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko.util.ByteString
 import me.maciejb.snappyflows.impl.Chunks.{CompressedData, UncompressedData}
 import me.maciejb.snappyflows.impl._
 import org.xerial.snappy.{PureJavaCrc32C, Snappy}

--- a/src/main/scala/me/maciejb/snappyflows/impl/ByteStringParser.scala
+++ b/src/main/scala/me/maciejb/snappyflows/impl/ByteStringParser.scala
@@ -1,8 +1,8 @@
 package me.maciejb.snappyflows.impl
 
-import akka.stream.{Attributes, Outlet, Inlet, FlowShape}
-import akka.stream.stage.{InHandler, GraphStageLogic, GraphStage}
-import akka.util.ByteString
+import org.apache.pekko.stream.{Attributes, Outlet, Inlet, FlowShape}
+import org.apache.pekko.stream.stage.{InHandler, GraphStageLogic, GraphStage}
+import org.apache.pekko.util.ByteString
 
 import scala.annotation.tailrec
 import scala.util.control.NoStackTrace

--- a/src/main/scala/me/maciejb/snappyflows/impl/Chunking.scala
+++ b/src/main/scala/me/maciejb/snappyflows/impl/Chunking.scala
@@ -1,10 +1,10 @@
 package me.maciejb.snappyflows.impl
 
-import akka.NotUsed
-import akka.stream.{Outlet, Inlet, Attributes, FlowShape}
-import akka.stream.scaladsl.Flow
-import akka.stream.stage._
-import akka.util.ByteString
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.{Outlet, Inlet, Attributes, FlowShape}
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.stage._
+import org.apache.pekko.util.ByteString
 
 
 private[snappyflows] object Chunking {

--- a/src/main/scala/me/maciejb/snappyflows/impl/Int24.scala
+++ b/src/main/scala/me/maciejb/snappyflows/impl/Int24.scala
@@ -1,6 +1,6 @@
 package me.maciejb.snappyflows.impl
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import me.maciejb.snappyflows.impl.ByteStringParser.ByteReader
 
 

--- a/src/main/scala/me/maciejb/snappyflows/impl/SnappyChunk.scala
+++ b/src/main/scala/me/maciejb/snappyflows/impl/SnappyChunk.scala
@@ -1,9 +1,9 @@
 package me.maciejb.snappyflows.impl
 
-import akka.NotUsed
-import akka.stream.Attributes
-import akka.stream.scaladsl.Flow
-import akka.util.ByteString
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.Attributes
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.util.ByteString
 import me.maciejb.snappyflows.impl.Chunks._
 import me.maciejb.snappyflows.{InvalidHeader, IllegalChunkFlag}
 import me.maciejb.snappyflows.impl.ByteStringParser.{ParseResult, ByteReader, ParseStep}

--- a/src/main/scala/me/maciejb/snappyflows/impl/SnappyFramed.scala
+++ b/src/main/scala/me/maciejb/snappyflows/impl/SnappyFramed.scala
@@ -1,6 +1,6 @@
 package me.maciejb.snappyflows.impl
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import me.maciejb.snappyflows.SnappyChecksum
 import org.xerial.snappy.Snappy
 

--- a/src/test/scala/me/maciejb/snappyflows/ManualTest.scala
+++ b/src/test/scala/me/maciejb/snappyflows/ManualTest.scala
@@ -1,8 +1,9 @@
 package me.maciejb.snappyflows
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.{Keep, Sink, StreamConverters}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.ActorMaterializer
+import org.apache.pekko.stream.scaladsl.{StreamConverters, Keep, Sink, Source}
+import org.apache.pekko.util.ByteString
 
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/src/test/scala/me/maciejb/snappyflows/RoundTripTest.scala
+++ b/src/test/scala/me/maciejb/snappyflows/RoundTripTest.scala
@@ -1,10 +1,10 @@
 package me.maciejb.snappyflows
 
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.{Keep, Sink, Source}
-import akka.testkit.{TestKit, TestKitBase}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+import org.apache.pekko.testkit.{TestKit, TestKitBase}
+import org.apache.pekko.util.ByteString
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec

--- a/src/test/scala/me/maciejb/snappyflows/Snzip.scala
+++ b/src/test/scala/me/maciejb/snappyflows/Snzip.scala
@@ -1,7 +1,10 @@
 package me.maciejb.snappyflows
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.{FileIO, Keep}
+import java.io.File
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.ActorMaterializer
+import org.apache.pekko.stream.scaladsl.{FileIO, Keep}
 
 import java.nio.file.Paths
 import scala.concurrent.Await

--- a/src/test/scala/me/maciejb/snappyflows/impl/ChunkingTest.scala
+++ b/src/test/scala/me/maciejb/snappyflows/impl/ChunkingTest.scala
@@ -1,9 +1,9 @@
 package me.maciejb.snappyflows.impl
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.{Keep, Sink, Source}
-import akka.testkit.TestKit
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.util.ByteString
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.1-SNAPSHOT"
+version in ThisBuild := "0.3.1-pekko.SNAPSHOT"


### PR DESCRIPTION
This provides a snappy-flows version compatible with the latest 1.0.1 release of the Apache pekko fork of akka